### PR TITLE
Update metrics name to align with schema.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Metric                     | description | namespace
 `http_requests_total`      | tracks api request | kong_http_requests_total
 `http_request_size_bytes`  | tracks api request's body size in bytes | kong_http_request_size_bytes
 `http_response_size_bytes` | tracks api response's body size in bytes | kong_http_response_size_bytes
-`http_request_duration_ms` | tracks the time interval between the request started and response received from the upstream server | kong_http_latency
+`http_request_duration_ms` | tracks the time interval between the request started and response received from the upstream server, stored as bucket | kong_http_latency
+`http_request_curr_duration_ms` | tracks the current time interval between the request started and response received from the upstream server |
 `http_upstream_duration_ms`| tracks the time it took for the final service to process the request | kong_http_upstream_latency
+`http_upstream_curr_duration_ms`| tracks the current time it took for the final service to process the request |
 `http_kong_duration_ms`    | tracks the internal Kong latency that it took to run all the plugins | kong_http_kong_latency
 
 ### Metric Fields

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ Metrics the plugin can expose in the prometheus format:
 
 Metric                     | description | namespace
 ---                        | ---         | ---
-`http_requests_total`            | tracks api request | kong_http_requests_total
-`http_request_size_bytes`             | tracks api request's body size in bytes | kong_http_request_size_bytes
-`http_response_size_bytes`            | tracks api response's body size in bytes | kong_http_response_size_bytes
-`http_request_duration_ms`                  | tracks the time interval between the request started and response received from the upstream server | kong_http_latency
-`http_upstream_latency`         | tracks the time it took for the final service to process the request | kong_http_upstream_latency
-`http_kong_latency`             | tracks the internal Kong latency that it took to run all the plugins | kong_http_kong_latency
+`http_requests_total`      | tracks api request | kong_http_requests_total
+`http_request_size_bytes`  | tracks api request's body size in bytes | kong_http_request_size_bytes
+`http_response_size_bytes` | tracks api response's body size in bytes | kong_http_response_size_bytes
+`http_request_duration_ms` | tracks the time interval between the request started and response received from the upstream server | kong_http_latency
+`http_upstream_duration_ms`| tracks the time it took for the final service to process the request | kong_http_upstream_latency
+`http_kong_duration_ms`    | tracks the internal Kong latency that it took to run all the plugins | kong_http_kong_latency
 
 ### Metric Fields
 
 Plugin can be configured with any combination of [Metrics](#metrics), with each entry containing the following fields.
 
 Field         | description                                             | allowed values
----           | ---                                                     | --- 
+---           | ---                                                     | ---
 `name`          | Prometheus metric's name                              | [Metrics](#metrics)          
 `stat_type`     | determines what sort of event the metric represents   | `gauge`, `counter` and `histogram`
 

--- a/logger.lua
+++ b/logger.lua
@@ -26,7 +26,7 @@ local function update_metric(metric_name, stat_type, stat_value, label_values)
 
   if stat_type == "counter" then
     metric:inc(stat_value, label_values)
-    
+
   elseif stat_type == "gauge" then
     metric:set(stat_value, label_values)
 
@@ -56,7 +56,7 @@ function PrometheusLogger:init(config)
     ngx_log(NGX_DEBUG, string.format("Prometheus: init metric %s", metric_config.name))
     if metric_config.stat_type == "counter" then
       metrics[metric_config.name] = prometheus:counter(metric_config.name, metric_config.description, metric_config.labels)
-    
+
     elseif metric_config.stat_type == "gauge" then
       metrics[metric_config.name] = prometheus:gauge(metric_config.name, metric_config.description, metric_config.labels)
 
@@ -77,18 +77,20 @@ function PrometheusLogger:log(message, config)
     api_name = string_gsub(message.api.name, "%.", "_")
   end
   local stat_value = {
-    http_request_size_bytes   = tonumber(message.request.size),
-    http_response_size_bytes  = tonumber(message.response.size),
-    http_request_duration_ms  = message.latencies.request,
-    http_upstream_duration_ms = message.latencies.proxy,
-    http_kong_duration_ms     = message.latencies.kong,
+    http_request_size_bytes        = tonumber(message.request.size),
+    http_response_size_bytes       = tonumber(message.response.size),
+    http_request_duration_ms       = message.latencies.request,
+    http_request_curr_duration_ms  = message.latencies.request,
+    http_upstream_duration_ms      = message.latencies.proxy,
+    http_upstream_curr_duration_ms = message.latencies.proxy,
+    http_kong_duration_ms          = message.latencies.kong,
     http_requests_total            = 1,
   }
 
   for _, metric_config in pairs(config.metrics) do
     local stat_value = stat_value[metric_config.name]
     if stat_value ~= nil then
-    
+
       local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
       local consumer_id
       if get_consumer_id ~= nil then

--- a/schema.lua
+++ b/schema.lua
@@ -1,10 +1,12 @@
 local metrics = {
   ["http_requests_total"]            = true,
-  ["http_request_duration_ms"]  = true,
+  ["http_request_duration_ms"]       = true,
+  ["http_request_curr_duration_ms"]  = true,
   ["http_request_size_bytes"]        = true,
   ["http_response_size_bytes"]       = true,
-  ["http_upstream_duration_ms"] = true,
-  ["http_kong_duration_ms"]     = true,
+  ["http_upstream_duration_ms"]      = true,
+  ["http_upstream_curr_duration_ms"] = true,
+  ["http_kong_duration_ms"]          = true,
   ["http_connections"]               = true,
 }
 
@@ -36,6 +38,12 @@ local default_metrics = {
     labels      = {"api"},
   },
   {
+    name        = "http_request_curr_duration_ms",
+    description = "Current HTTP request latency",
+    stat_type   = "gauge",
+    labels      = {"api"},
+  },
+  {
     name        = "http_request_size_bytes",
     description = "Size of HTTP responses",
     stat_type   = "histogram",
@@ -51,6 +59,11 @@ local default_metrics = {
   {
     name      = "http_upstream_duration_ms",
     stat_type = "histogram",
+    labels      = {"api"},
+  },
+  {
+    name      = "http_upstream_curr_duration_ms",
+    stat_type = "gauge",
     labels      = {"api"},
   },
   {


### PR DESCRIPTION
Seems the actual metrics names used in schema.lua are not aligned with README.md