### PR TITLE
Fix when there is one short circuiting, http_upstream_duration_ms ret…

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -30,7 +30,7 @@ local function update_metric(metric_name, stat_type, stat_value, label_values)
 
   if stat_type == "counter" then
     metric:inc(stat_value, label_values)
-    
+
   elseif stat_type == "gauge" then
     metric:set(stat_value, label_values)
 
@@ -61,7 +61,7 @@ function PrometheusLogger:init(config)
     ngx_log(NGX_DEBUG, string.format("Prometheus: init metric %s", metric_fullname))
     if metric_config.stat_type == "counter" then
       metrics[metric_fullname] = prometheus:counter(metric_fullname, metric_config.description, metric_config.labels)
-    
+
     elseif metric_config.stat_type == "gauge" then
       metrics[metric_fullname] = prometheus:gauge(metric_fullname, metric_config.description, metric_config.labels)
 
@@ -86,11 +86,13 @@ function PrometheusLogger:log(message, config)
   else
     api_name = string_gsub(message.api.name, "%.", "_")
   end
+
+  local proxy_latency = tonumber(message.latencies.proxy)
   local stat_value = {
     http_request_size_bytes        = tonumber(message.request.size),
     http_response_size_bytes       = tonumber(message.response.size),
     http_request_duration_ms       = tonumber(message.latencies.request),
-    http_upstream_duration_ms      = tonumber(message.latencies.proxy),
+    http_upstream_duration_ms      = (proxy_latency == -1) and 0 or proxy_latency,
     http_kong_duration_ms          = tonumber(message.latencies.kong),
     http_requests_total            = 1,
   }
@@ -98,7 +100,7 @@ function PrometheusLogger:log(message, config)
   for _, metric_config in pairs(config.metrics) do
     local stat_value = stat_value[metric_config.name]
     if stat_value ~= nil then
-    
+
       local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
       local consumer_id
       if get_consumer_id ~= nil then


### PR DESCRIPTION
When there is one short circuiting, `http_upstream_duration_ms` returns a negative duration. In this commit, I zero-out the `http_upstream_duration_ms` instead of passing it to nginx-lua-prometheus as negative.