### PR TITLE
add default buckets to use an integer number in milliseconds

### DIFF
--- a/schema.lua
+++ b/schema.lua
@@ -34,6 +34,8 @@ local default_metrics = {
     description = "HTTP request latency",
     stat_type   = "histogram",
     labels      = {"api"},
+    -- Default set of latency buckets, 1ms to 10s:
+    buckets     = {1,5,10,100,1000,10000,100000},
   },
   {
     name        = "http_request_size_bytes",
@@ -52,6 +54,7 @@ local default_metrics = {
     name      = "http_upstream_duration_ms",
     stat_type = "histogram",
     labels      = {"api"},
+    buckets     = {1,5,10,100,1000,10000,100000},
   },
   {
     name      = "http_upstream_duration_ms",
@@ -62,6 +65,7 @@ local default_metrics = {
     name      = "http_kong_duration_ms",
     stat_type = "histogram",
     labels      = {"api"},
+    buckets     = {1,5,10,100,1000,10000,100000},
   },
   {
     name        = "http_connections",


### PR DESCRIPTION
By default, nginx-lua-prometheus use a floating-point number for the elapsed time in seconds. But Kong use an interger precision in milliseconds. Due to latency accuracy, I add these default buckets to fix it.

#19 